### PR TITLE
fix: use dedicated endpoints

### DIFF
--- a/pushnotifier/PushNotifier.py
+++ b/pushnotifier/PushNotifier.py
@@ -21,8 +21,10 @@ class PushNotifier:
         self.login_url = self.base_url + '/user/login'
         self.devices_url = self.base_url + '/devices'
         self.refresh_url = self.base_url + '/user/refresh'
-        self.send_text_url = self.base_url + '/notifications/text'
-        self.send_image_url = self.base_url + '/notifications/image'
+        self.endpoint_text = self.base_url + '/notifications/text'
+        self.endpoint_url = self.base_url + '/notifications/url'
+        self.endpoint_image = self.base_url + '/notifications/image'
+        self.endpoint_notification = self.base_url + '/notifications/notification'
         self.username = username
         self.package_name = package_name
         self.api_key = api_key
@@ -53,7 +55,8 @@ class PushNotifier:
             'username': self.username,
             'password': password
         }
-        r = requests.post(self.login_url, data=login_data, auth=(self.package_name, self.api_key))
+        r = requests.post(self.login_url, data=login_data,
+                          auth=(self.package_name, self.api_key))
 
         if r.status_code == 401:
             raise UnauthorizedError
@@ -125,7 +128,7 @@ class PushNotifier:
                 "silent": silent
             }
 
-        r = requests.put(self.send_text_url, json=body, auth=(
+        r = requests.put(self.endpoint_text, json=body, auth=(
             self.package_name, self.api_key), headers=self.headers)
         if r.status_code == 200:
             return 200
@@ -154,17 +157,17 @@ class PushNotifier:
         if devices == None:
             body = {
                 "devices": self.get_all_devices(),
-                "content": url,
+                "url": url,
                 "silent": silent
             }
         else:
             body = {
                 "devices": devices,
-                "content": url,
+                "url": url,
                 "silent": silent
             }
 
-        r = requests.put(self.send_text_url, json=body, auth=(
+        r = requests.put(self.endpoint_url, json=body, auth=(
             self.package_name, self.api_key), headers=self.headers)
 
         if r.status_code == 200:
@@ -207,7 +210,7 @@ class PushNotifier:
                 "silent": silent
             }
 
-        r = requests.put(self.send_text_url, json=body, auth=(
+        r = requests.put(self.endpoint_notification, json=body, auth=(
             self.package_name, self.api_key), headers=self.headers)
 
         if r.status_code == 200:
@@ -261,7 +264,7 @@ class PushNotifier:
                 "silent": silent
             }
 
-        r = requests.put(self.send_image_url, json=body, auth=(
+        r = requests.put(self.endpoint_image, json=body, auth=(
             self.package_name, self.api_key), headers=self.headers)
 
         if r.status_code == 200:


### PR DESCRIPTION
The module use for the three actions (text, url, notification) the same endpoint: `/notifications/text`
Since the type of notification matters, e.g. as a display in the app and the follow-up actions there (open URL directly), I made a distinction between these three actions and added the following two endpoints from the [docu](https://api.pushnotifier.de/v2/doc/#endpoint-put-send-a-url):
- `/notifications/url`
- `/notifications/notification`

To be consistent I additionally renamed also the image endpoint.


![image](https://user-images.githubusercontent.com/32959219/198826838-b9e5748f-3b08-4a58-9e5b-bdb73e617a02.png)
